### PR TITLE
INT-1766 fix nil error value from CreatePickup

### DIFF
--- a/fedex.go
+++ b/fedex.go
@@ -57,7 +57,8 @@ func (f Fedex) CreatePickup(pickup *models.Pickup) (*models.PickupSuccess, error
 		fields := log.Fields{"pickup": pickup}
 
 		// Calculate pickup window, but just try the next window in case of error
-		window, err := pickupTimeWindow(pickup.PickupLocation.Address, delay)
+		var window *models.PickupTimeWindow
+		window, err = pickupTimeWindow(pickup.PickupLocation.Address, delay)
 		if err != nil {
 			log.WithFields(fields).Error("calculate pickup time", err)
 			continue


### PR DESCRIPTION
err was declared inside of for loop, but attempted to access outside of the loop, resulting in the returned error always being nil. Fix this by using the err var declared in function.