### PR TITLE
HUB-2837: Pickup retry logic allow creating pickups without retries internally

### DIFF
--- a/fedex.go
+++ b/fedex.go
@@ -47,6 +47,35 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
+// Retry logic is expected to be implemented by the caller
+func (f Fedex) CreatePickupNoRetry(pickup *models.Pickup, startTime time.Time, endTime time.Time) (*models.PickupSuccess, error) {
+	fields := log.Fields{"pickup": pickup}
+	window := &models.PickupTimeWindow{ReadyTime: startTime, CloseTime: endTime}
+
+	fields["window"] = window
+	reply, err := f.API.CreatePickup(pickup, window)
+	switch err.(type) {
+	case nil:
+		fields["reply"] = reply
+		log.WithFields(fields).Info("made pickup")
+		return &models.PickupSuccess{
+			ConfirmationNumber: reply.PickupConfirmationNumber,
+			Window:             *window,
+		}, nil
+
+	case models.PickupAlreadyExistsError:
+		fields["reply"] = reply
+		log.WithFields(fields).Info("pickup already exists")
+		return nil, fmt.Errorf("pickup already exists %w", err)
+
+	default:
+		fields["err"] = err
+		log.WithFields(fields).Info("failed pickup %w", err)
+	}
+
+	return nil, fmt.Errorf("unable to schedule a fedex pickup")
+}
+
 // CreatePickup creates a pickup with retry logic to try pickups on different days/times
 func (f Fedex) CreatePickup(pickup *models.Pickup) (*models.PickupSuccess, error) {
 	for delay := 0; delay <= 5; delay++ {

--- a/fedex.go
+++ b/fedex.go
@@ -7,11 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/happyreturns/fedex/api"
-	"github.com/happyreturns/fedex/clock"
 	"github.com/happyreturns/fedex/models"
 	log "github.com/sirupsen/logrus"
 )
@@ -34,25 +32,16 @@ type Fedex struct {
 	api.API
 }
 
-var laTimeZone *time.Location
-
 func init() {
-	var err error
-	laTimeZone, err = time.LoadLocation("America/Los_Angeles")
-	if err != nil {
-		panic(err)
-	}
-
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stdout)
 }
 
 // Retry logic is expected to be implemented by the caller
-func (f Fedex) CreatePickupNoRetry(pickup *models.Pickup, startTime time.Time, endTime time.Time) (*models.PickupSuccess, error) {
-	fields := log.Fields{"pickup": pickup}
+func (f Fedex) CreatePickup(pickup *models.Pickup, startTime time.Time, endTime time.Time) (*models.PickupSuccess, error) {
 	window := &models.PickupTimeWindow{ReadyTime: startTime, CloseTime: endTime}
+	fields := log.Fields{"pickup": pickup, "window": window}
 
-	fields["window"] = window
 	reply, err := f.API.CreatePickup(pickup, window)
 	switch err.(type) {
 	case nil:
@@ -74,115 +63,6 @@ func (f Fedex) CreatePickupNoRetry(pickup *models.Pickup, startTime time.Time, e
 	}
 
 	return nil, fmt.Errorf("unable to schedule a fedex pickup")
-}
-
-// CreatePickup creates a pickup with retry logic to try pickups on different days/times
-func (f Fedex) CreatePickup(pickup *models.Pickup) (*models.PickupSuccess, error) {
-	for delay := 0; delay <= 5; delay++ {
-		pickupOffset := &models.PickupOffset{Days: delay, Hours: 10, Minutes: 45}
-		pickupSuccess := f.bookPickup(pickup, pickupOffset)
-		if pickupSuccess != nil {
-			return pickupSuccess, nil
-		}
-	}
-
-	for delay := 0; delay <= 5; delay++ {
-		pickupOffset := &models.PickupOffset{Days: delay, Hours: 10, Minutes: 0}
-		pickupSuccess := f.bookPickup(pickup, pickupOffset)
-		if pickupSuccess != nil {
-			return pickupSuccess, nil
-		}
-	}
-
-	return nil, fmt.Errorf("unable to schedule a fedex pickup")
-}
-
-func (f Fedex) bookPickup(pickup *models.Pickup, pickupOffset *models.PickupOffset) *models.PickupSuccess {
-	fields := log.Fields{"pickup": pickup}
-
-	window, err := pickupTimeWindow(clock.NewClock(), pickup.PickupLocation.Address, pickupOffset)
-	if err != nil {
-		log.WithFields(fields).Error("calculate pickup time", err)
-		return nil
-	}
-	fields["window"] = window
-
-	reply, err := f.API.CreatePickup(pickup, window)
-	switch err.(type) {
-	case nil:
-		fields["reply"] = reply
-		log.WithFields(fields).Info("made pickup")
-		return &models.PickupSuccess{
-			ConfirmationNumber: reply.PickupConfirmationNumber,
-			Window:             *window,
-		}
-
-	case models.PickupAlreadyExistsError:
-		fields["reply"] = reply
-		log.WithFields(fields).Info("pickup already exists")
-		return nil
-
-	default:
-		fields["err"] = err
-		log.WithFields(fields).Info("failed pickup")
-	}
-
-	return nil
-}
-
-func pickupTimeWindow(clock clock.Clock, pickupAddress models.Address, pickupOffset *models.PickupOffset) (*models.PickupTimeWindow, error) {
-	location, err := toLocation(pickupAddress)
-	if err != nil {
-		location = laTimeZone
-	}
-
-	readyTime := clock.Now().In(location).Add(time.Duration(pickupOffset.Days*24) * time.Hour)
-
-	// If it's past the ready time of the current day, ship the next day, not today
-	if readyTime.After(timeForReadyPickup(readyTime, pickupOffset)) {
-		readyTime = readyTime.Add(24 * time.Hour)
-	}
-	readyTime = timeForReadyPickup(readyTime, pickupOffset)
-
-	// Don't schedule pickups for Sunday
-	if readyTime.Weekday() == time.Sunday {
-		return nil, fmt.Errorf("no pickups on sunday %d", pickupOffset.Days)
-	}
-
-	return &models.PickupTimeWindow{
-		ReadyTime: readyTime,
-		CloseTime: readyTime.Add(8 * time.Hour),
-	}, nil
-}
-
-func timeForReadyPickup(t time.Time, pickupOffset *models.PickupOffset) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), pickupOffset.Hours, pickupOffset.Minutes, 0, 0, t.Location())
-}
-
-// toLocation attempts to return the timezone based on state, returning los
-// angeles if unable to
-func toLocation(pickupAddress models.Address) (*time.Location, error) {
-	tzDatabaseName := ""
-	switch strings.ToUpper(pickupAddress.StateOrProvinceCode) {
-	case "AK":
-		tzDatabaseName = "America/Anchorage"
-	case "HI":
-		tzDatabaseName = "Pacific/Honolulu"
-	case "AL", "AR", "IL", "IA", "KS", "KY", "LA", "MN", "MS", "MO", "NE", "ND", "OK", "SD", "TN", "TX", "WI":
-		tzDatabaseName = "America/Chicago"
-	case "AZ", "CO", "ID", "MT", "NM", "UT", "WY":
-		tzDatabaseName = "America/Denver"
-	case "CT", "DC", "DE", "FL", "GA", "IN", "ME", "MD", "MA", "MI", "NH", "NJ", "NY", "NC", "OH", "PA", "RI", "SC", "VT", "VA", "WV":
-		tzDatabaseName = "America/New_York"
-	default:
-		return laTimeZone, nil
-	}
-
-	timeZone, err := time.LoadLocation(tzDatabaseName)
-	if err != nil {
-		return nil, fmt.Errorf("load location from time zone %s: %s", tzDatabaseName, err)
-	}
-	return timeZone, nil
 }
 
 func (f Fedex) Ship(shipment *models.Shipment) (*models.ProcessShipmentReply, error) {

--- a/fedex_test.go
+++ b/fedex_test.go
@@ -10,8 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	clockMock "github.com/happyreturns/fedex/clock/mocks"
 	"github.com/happyreturns/fedex/models"
 	"github.com/stretchr/testify/assert"
 )
@@ -540,6 +538,16 @@ func TestCreatePickup(t *testing.T) {
 	// This will fail if there's a pickup already scheduled. Delete the pickup in
 	// the FedEx console to run the test in that case
 	t.SkipNow()
+
+	laTimeZone, err := time.LoadLocation("America/Los_Angeles")
+	if err != nil {
+		panic(err)
+	}
+
+	today := time.Now().In(laTimeZone)
+	startTime := time.Date(today.Year(), today.Month(), today.Day(), 10, 45, 0, 0, laTimeZone)
+	endTime := time.Date(today.Year(), today.Month(), today.Day(), 18, 45, 0, 0, laTimeZone)
+
 	pickup := &models.Pickup{
 		PickupLocation: models.PickupLocation{
 			Address: models.Address{
@@ -563,7 +571,7 @@ func TestCreatePickup(t *testing.T) {
 		},
 	}
 
-	success, err := prodFedex.CreatePickup(pickup)
+	success, err := prodFedex.CreatePickup(pickup, startTime, endTime)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -574,28 +582,12 @@ func TestCreatePickup(t *testing.T) {
 
 	readyTime := success.Window.ReadyTime
 	closeTime := success.Window.CloseTime
-	today := time.Now().In(laTimeZone)
-	tomorrow := today.Add(24 * time.Hour)
-	if !readyTime.Equal(time.Date(today.Year(), today.Month(), today.Day(), 10, 45, 0, 0, laTimeZone)) &&
-		!readyTime.Equal(time.Date(tomorrow.Year(), tomorrow.Month(), tomorrow.Day(), 10, 45, 0, 0, laTimeZone)) {
-		t.Fatal("readyTime should set at 10:45 either today or tomorrow")
-	}
 
-	if !closeTime.Equal(time.Date(readyTime.Year(), readyTime.Month(), readyTime.Day(), 18, 45, 0, 0, laTimeZone)) {
-		t.Fatal("closeTime should set at 18:45 on the same day as the ready time")
-	}
+	assert.Equal(t, startTime.Hour(), readyTime.Hour())
+	assert.Equal(t, startTime.Minute(), readyTime.Minute())
 
-	success, err = prodFedex.CreatePickup(pickup)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if success.ConfirmationNumber != "" {
-		t.Fatal("confirmation number should be empty since the pickup already exists")
-	}
-	if success.Window.ReadyTime != readyTime || success.Window.CloseTime != closeTime {
-		t.Fatal("readyTime and closeTime should be the same from the previous pickup call")
-	}
+	assert.Equal(t, endTime.Hour(), closeTime.Hour())
+	assert.Equal(t, endTime.Minute(), closeTime.Minute())
 }
 
 func TestSendNotifications(t *testing.T) {
@@ -724,101 +716,6 @@ func testShipSmartPostSuccess(t *testing.T, fedexAccount Fedex) {
 		fmt.Println(reply)
 		t.Fatal("reply should not have failed")
 	}
-}
-
-func TestPickupTimeWindow(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	t.Run("happy path", func(t *testing.T) {
-		mockClock := clockMock.NewMockClock(ctrl)
-		testDate := time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
-		mockClock.EXPECT().Now().Return(testDate).Times(1)
-
-		pickupOffset := &models.PickupOffset{Days: 0, Hours: 10, Minutes: 45}
-		pickupAddress := models.Address{StateOrProvinceCode: "CA"}
-		pickupTimeWindow, err := pickupTimeWindow(mockClock, pickupAddress, pickupOffset)
-		assert.Nil(t, err)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Hour(), 10)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Minute(), 45)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Hour(), 18)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Minute(), 45)
-	})
-
-	t.Run("earlier pickup", func(t *testing.T) {
-		mockClock := clockMock.NewMockClock(ctrl)
-		testDate := time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
-		mockClock.EXPECT().Now().Return(testDate).Times(1)
-
-		pickupOffset := &models.PickupOffset{Days: 0, Hours: 10, Minutes: 0}
-		pickupAddress := models.Address{StateOrProvinceCode: "CA"}
-		pickupTimeWindow, err := pickupTimeWindow(mockClock, pickupAddress, pickupOffset)
-		assert.Nil(t, err)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Hour(), 10)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Minute(), 0)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Hour(), 18)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Minute(), 0)
-	})
-
-	t.Run("pickup with day delay", func(t *testing.T) {
-		mockClock := clockMock.NewMockClock(ctrl)
-		testDate := time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
-		mockClock.EXPECT().Now().Return(testDate).Times(1)
-
-		pickupOffset := &models.PickupOffset{Days: 3, Hours: 10, Minutes: 0}
-		pickupAddress := models.Address{StateOrProvinceCode: "CA"}
-		pickupTimeWindow, err := pickupTimeWindow(mockClock, pickupAddress, pickupOffset)
-		assert.Nil(t, err)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Day(), 5)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Hour(), 10)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Minute(), 0)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Day(), 5)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Hour(), 18)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Minute(), 0)
-	})
-
-	t.Run("pickup time past current time", func(t *testing.T) {
-		mockClock := clockMock.NewMockClock(ctrl)
-		testDate := time.Date(2023, 1, 2, 11, 0, 0, 0, time.UTC)
-		mockClock.EXPECT().Now().Return(testDate).Times(1)
-
-		pickupOffset := &models.PickupOffset{Days: 0, Hours: 10, Minutes: 0}
-		pickupAddress := models.Address{StateOrProvinceCode: "CA"}
-		pickupTimeWindow, err := pickupTimeWindow(mockClock, pickupAddress, pickupOffset)
-		assert.Nil(t, err)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Day(), 3)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Hour(), 10)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Minute(), 0)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Day(), 3)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Hour(), 18)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Minute(), 0)
-	})
-
-	t.Run("sunday pickup", func(t *testing.T) {
-		mockClock := clockMock.NewMockClock(ctrl)
-		testDate := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
-		mockClock.EXPECT().Now().Return(testDate).Times(1)
-
-		pickupOffset := &models.PickupOffset{Days: 0, Hours: 10, Minutes: 0}
-		pickupAddress := models.Address{StateOrProvinceCode: "CA"}
-		_, err := pickupTimeWindow(mockClock, pickupAddress, pickupOffset)
-		assert.NotNil(t, err)
-	})
-
-	t.Run("no state provided", func(t *testing.T) {
-		mockClock := clockMock.NewMockClock(ctrl)
-		testDate := time.Date(2023, 1, 2, 0, 0, 0, 0, time.UTC)
-		mockClock.EXPECT().Now().Return(testDate).Times(1)
-
-		pickupOffset := &models.PickupOffset{Days: 0, Hours: 10, Minutes: 45}
-		pickupAddress := models.Address{StateOrProvinceCode: "no state"}
-		pickupTimeWindow, err := pickupTimeWindow(mockClock, pickupAddress, pickupOffset)
-		assert.Nil(t, err)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Hour(), 10)
-		assert.Equal(t, pickupTimeWindow.ReadyTime.Minute(), 45)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Hour(), 18)
-		assert.Equal(t, pickupTimeWindow.CloseTime.Minute(), 45)
-	})
 }
 
 func checkErrorMatches(t *testing.T, err error, expectedText string) {

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/onsi/gomega v1.16.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.8.0
+	github.com/stretchr/testify v1.8.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=


### PR DESCRIPTION
I *could* remove the other implementation/code however there are apparently other references to it within the happyreturns organization.