### PR TITLE
HUB-3246: allow express saver accounts for fedex

### DIFF
--- a/models/api_process_shipment.go
+++ b/models/api_process_shipment.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func (s *Shipment) ServiceType() string {
-	return ServiceType(s.FromAndTo, s.Service)
+	return ServiceType(s.FromAndTo, s.Service, s.MethodServiceLevel)
 }
 
 func (s *Shipment) Broker() string {

--- a/models/api_rate.go
+++ b/models/api_rate.go
@@ -16,7 +16,7 @@ type Rate struct {
 }
 
 func (r *Rate) ServiceType() string {
-	serviceType := ServiceType(r.FromAndTo, r.Service, "")
+	serviceType := ServiceType(r.FromAndTo, r.Service, r.Service)
 	if serviceType == ServiceTypeSmartPost {
 		// This is necessary. We can't get back smartpost rates. So using ground
 		// instead here.

--- a/models/api_rate.go
+++ b/models/api_rate.go
@@ -16,7 +16,7 @@ type Rate struct {
 }
 
 func (r *Rate) ServiceType() string {
-	serviceType := ServiceType(r.FromAndTo, r.Service)
+	serviceType := ServiceType(r.FromAndTo, r.Service, "")
 	if serviceType == ServiceTypeSmartPost {
 		// This is necessary. We can't get back smartpost rates. So using ground
 		// instead here.

--- a/models/const.go
+++ b/models/const.go
@@ -47,6 +47,7 @@ const (
 	ServiceTypeInternationalEconomy        = "INTERNATIONAL_ECONOMY"
 	ServiceTypeInternationalEconomyFreight = "INTERNATIONAL_ECONOMY_FREIGHT"
 	ServiceTypeSmartPost                   = "SMART_POST"
+	ServiceTypeExpressSaver                = "FEDEX_EXPRESS_SAVER"
 
 	SpecialServiceTypeElectronicTradeDocuments = "ELECTRONIC_TRADE_DOCUMENTS"
 	SpecialServiceTypeReturnShipment           = "RETURN_SHIPMENT"

--- a/models/service_type.go
+++ b/models/service_type.go
@@ -3,7 +3,7 @@ package models
 // ServiceType determines the service type (the FedEx API field) based on the
 // service (the HR-defined property) and the source/destination. Needed for
 // both rates and shipments. Ideally I don't think this should live in models.
-func ServiceType(fromAndTo FromAndTo, service string) string {
+func ServiceType(fromAndTo FromAndTo, service string, serviceLevel string) string {
 	// TODO This is confusing. If the service is marked as "fedex_smart_post" or
 	// "fedex_international_economy" (this is done through the CMS), then
 	// explicitly set the service type as SmartPost or InternationalEconomy
@@ -17,12 +17,16 @@ func ServiceType(fromAndTo FromAndTo, service string) string {
 	isInternational := fromAndTo.IsInternational()
 	shipsOutWithInternationalEconomy := fromAndTo.FromAddress.ShipsOutWithInternationalEconomy()
 	switch {
-	case service == "fedex_smart_post",
-		service == "return" && !isInternational:
+
+	case service == "fedex_smart_post", service == "return" && !isInternational:
 		return ServiceTypeSmartPost
-	case service == "fedex_international_economy" ||
-		(isInternational && shipsOutWithInternationalEconomy):
+
+	case service == "fedex_international_economy" || (isInternational && shipsOutWithInternationalEconomy):
 		return ServiceTypeInternationalEconomy
+
+	case serviceLevel == "fedex_express":
+		return ServiceTypeExpressSaver
+
 	default:
 		return ServiceTypeFedexGround
 	}

--- a/models/service_type.go
+++ b/models/service_type.go
@@ -24,7 +24,7 @@ func ServiceType(fromAndTo FromAndTo, service string, serviceLevel string) strin
 	case service == "fedex_international_economy" || (isInternational && shipsOutWithInternationalEconomy):
 		return ServiceTypeInternationalEconomy
 
-	case serviceLevel == "fedex_express":
+	case service == "fedex_express" || serviceLevel == "fedex_express":
 		return ServiceTypeExpressSaver
 
 	default:


### PR DESCRIPTION
The existing logic is confusing but basically:

- Shipping service doesn't ever send the `service` string forward. It only sends the `service_level` as `service`.
- We only create FedEx "Return Shipments" if the user account is "FedEx Smart Post"

We want to support FedEx Express, which will be implemented through `service_level = 'fedex_express'`. These will require us to set a new field for fetching the *rates* and for *creating shipments*.