### PR TITLE
[DO NOT MERGE] IN-9857 spike: CodeQL Go autobuild floor test

### DIFF
--- a/.github/workflows/ci_security_test.yaml
+++ b/.github/workflows/ci_security_test.yaml
@@ -1,0 +1,60 @@
+# TEMP test workflow (IN-9857 Step 0 spike) — validates CodeQL Go autobuild on a real Linux runner.
+# `upload: false` skips the GHAS code-scanning upload, so it proves the build/extract/analyze path
+# (timings + private-module auth + cgo) WITHOUT needing GHAS enabled. DO NOT MERGE.
+name: CI Security Test (upload-false)
+run-name: ci_security floor test — ${{ github.event.repository.name }}
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  codeql-go:
+    name: codeql-go (autobuild, upload-false)
+    runs-on:
+      group: ${{ vars.RUNNER_DEV_CI_SIMPLE }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Configure private-module auth
+        env:
+          PAT: ${{ secrets.INFRA_BOT_V2_PAT }}
+        run: |
+          git config --global url."https://${PAT}@github.com/".insteadOf "https://github.com/"
+          go env -w GOPRIVATE=github.com/happyreturns/*
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          build-mode: autobuild
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Analyze (no upload)
+        uses: github/codeql-action/analyze@v3
+        with:
+          upload: false
+          output: codeql-results
+
+      - name: Upload SARIF artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-sarif-${{ github.event.repository.name }}
+          path: codeql-results/*.sarif
+          if-no-files-found: warn


### PR DESCRIPTION
**DO NOT MERGE** — IN-9857 Step 0 spike. Temporary CodeQL Go autobuild workflow (`upload:false`, no GHAS) to measure real CI-runner scan time on this single-module repo. Left open for review; will be closed after timings are collected.